### PR TITLE
md keys are bytes

### DIFF
--- a/libmilter.py
+++ b/libmilter.py
@@ -756,10 +756,10 @@ class MilterProtocol(object):
         if cmd is not None:
             md = dictFromCmd(cmd[2:])
         data = data[0]
-        hostname = ''
+        hostname = b''
         family = ''
         port = -1
-        ip = ''
+        ip = b''
         if data:
             checkData(data , SMFIC_CONNECT)
             hostname , rem = readUntilNull(data[1:])
@@ -799,10 +799,10 @@ class MilterProtocol(object):
         if data:
             mfrom = data[1:-1]
         # Return the mail from address parsed by the MTA, if possible
-        if 'mail_addr' in md:
-            mfrom = md['mail_addr']
-        if 'i' in md:
-            self._qid = md['i']
+        if b'mail_addr' in md:
+            mfrom = md[b'mail_addr']
+        if b'i' in md:
+            self._qid = md[b'i']
         return self.mailFrom(mfrom , md)
 
     def _rcpt(self , cmd , data):
@@ -817,10 +817,10 @@ class MilterProtocol(object):
         rcpt = ''
         if data:
             rcpt = data[1:-1]
-        elif 'rcpt_addr' in md:
-            rcpt = md['rcpt_addr']
-        if 'i' in md:
-            self._qid = md['i']
+        elif b'rcpt_addr' in md:
+            rcpt = md[b'rcpt_addr']
+        if b'i' in md:
+            self._qid = md[b'i']
         return self.rcpt(rcpt , md)
 
     def _header(self , cmd , data):
@@ -834,8 +834,8 @@ class MilterProtocol(object):
         data = data[0]
         key = ''
         val = ''
-        if 'i' in md:
-            self._qid = md['i']
+        if b'i' in md:
+            self._qid = md[b'i']
         if data:
             key , rem = readUntilNull(data[1:])
             val , rem = readUntilNull(rem)
@@ -852,8 +852,8 @@ class MilterProtocol(object):
         md = {}
         if cmd is not None:
             md = dictFromCmd(cmd[2:])
-        if 'i' in md:
-            self._qid = md['i']
+        if b'i' in md:
+            self._qid = md[b'i']
         return self.eoh(md)
 
     def _data(self , cmd , data):
@@ -863,8 +863,8 @@ class MilterProtocol(object):
         md = {}
         if cmd is not None:
             md = dictFromCmd(cmd[2:])
-        if 'i' in md:
-            self._qid = md['i']
+        if b'i' in md:
+            self._qid = md[b'i']
         return self.data(md)
 
     def _body(self , cmd , data):
@@ -877,8 +877,8 @@ class MilterProtocol(object):
         if cmd is not None:
             md = dictFromCmd(cmd[2:])
         chunk = ''
-        if 'i' in md:
-            self._qid = md['i']
+        if b'i' in md:
+            self._qid = md[b'i']
         if data:
             chunk = data[1:]
         return self.body(chunk , md)
@@ -891,8 +891,8 @@ class MilterProtocol(object):
         md = {}
         if cmd is not None:
             md = dictFromCmd(cmd[2:])
-        if 'i' in md:
-            self._qid = md['i']
+        if b'i' in md:
+            self._qid = md[b'i']
         ret = self.eob(md)
         return ret
 


### PR DESCRIPTION
Hi,
just a quick pull request to change the keys of the `md` dictionaries to bytes, instead of strings.
BTW, thanks for this awesome module! :-)
Daniele